### PR TITLE
update to cardano-signer v1.27.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,8 @@
       pkgs.fetchFromGitHub {
         owner = "gitmachtl";
         repo = "cardano-signer";
-        rev = "2f23e2904ae08b98d3e1d383c0e5f2b94af30db8";
-        sha256 = "sha256-eeMonqsvFMqIZ2I/xdx69AkHMecnDjbPK1VmmFvO2hk=";
+        rev = "279d55684e04f274d0168689a9261f16267ef80e";
+        sha256 = "sha256-C8whKGOSidCGGZhuS9TFRfZfOzrFFw7knmIIFhHJ9TM=";
       };
 
     shortRev = commit: builtins.substring 0 7 commit;

--- a/yarn-279d556.lock
+++ b/yarn-279d556.lock
@@ -97,7 +97,7 @@ formdata-polyfill@^4.0.10:
   dependencies:
     fetch-blob "^3.1.2"
 
-jsonld@^8.3.2:
+jsonld@^8.3.3:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-8.3.3.tgz#08cc927833c8684e42319d4697cc8199c0908ffc"
   integrity sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==


### PR DESCRIPTION
Hi, there is a bug in the old version of cardano-signer; see below to reproduce. This is why this PR updates to cardano-signer v1.27.0.

# BUG reproduce
Given this gov action ([link](https://cardanoscan.io/govAction/gov_action18nefry4qacd80xzs2srjahxm2e4vz3c8wvrr03rrtk8mdqfuknysq66459t?tab=meta)), we have ipfs hash `https://ipfs.io/ipfs/bafkreihj3ddbz7c52l2s3klalsf4ux5xqkawktom5v5apfral37hs6kpki` and blake256 hash of this data of `daef7fd77381f73cb8ac592762e4073cf18c756d347aefadc8a5bc32c1383a1b`. Now note the following,

1. To sign a metadata file, you canonnical the body of the metadata, blake2b-245 hash it and then sign over that
2. There is some error in the metadata @context (JSONLD junk) which causes the cannonize step to stop half way though
3. during the error in cannonizing, cardano-signer didn't throw an error, and instead only signed over a small part of the cannonizlied body
4. this has now been fixed in the release of [cardano-signer 1.27.0](https://github.com/gitmachtl/cardano-signer/releases/tag/v1.27.0) this morning

Thanks to @Ryun1 for the above four points. This makes the following happen
```bash
curl -s -o cip100-data.json "https://bafkreihj3ddbz7c52l2s3klalsf4ux5xqkawktom5v5apfral37hs6kpki.ipfs.dweb.link/"
cat cip100-data.json | b2sum -l 256
```
gives
```bash
daef7fd77381f73cb8ac592762e4073cf18c756d347aefadc8a5bc32c1383a1b  -
```
But also we have that for the latest (as of writing) main we have
```bash
nix run github:johnalotoski/cardano-signer/1a07e1376788f3615138aa05bc0dce83da429927#cardano-signer -- verify --cip100 --data-file cip100-data.json
```
which gives and invalid
```bash
true
```
But with version v1.27.0 we get for
```bash
nix run github:perturbing/cardano-signer-nix/7bd446f7b0297de28215bde129f129eaf011e824#cardano-signer -- verify --cip100 --data-file cip100-data.json
```
gives
```bash
Error: Could not verify the data (Safe mode validation error.)
```
